### PR TITLE
Update Makefile, add more archs / go crossbuild

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,24 @@ cross:
 	CGO_ENABLED=0 GOOS=freebsd   GOARCH=amd64 $(GO) build -o ./bin/norouter-FreeBSD-amd64    ./cmd/norouter
 	CGO_ENABLED=0 GOOS=netbsd    GOARCH=amd64 $(GO) build -o ./bin/norouter-NetBSD-amd64     ./cmd/norouter
 	CGO_ENABLED=0 GOOS=openbsd   GOARCH=amd64 $(GO) build -o ./bin/norouter-OpenBSD-amd64    ./cmd/norouter
+	CGO_ENABLED=0 GOOS=openbsd   GOARCH=arm64 $(GO) build -o ./bin/norouter-OpenBSD-arm64    ./cmd/norouter
 	CGO_ENABLED=0 GOOS=dragonfly GOARCH=amd64 $(GO) build -o ./bin/norouter-DragonFly-x86_64 ./cmd/norouter
 	CGO_ENABLED=0 GOOS=windows   GOARCH=amd64 $(GO) build -o ./bin/norouter-Windows-x64.exe  ./cmd/norouter
+	CGO_ENABLED=0 GOOS=linux     GOARCH=arm64 $(GO) build -o ./bin/norouter-Linux-aarch64    ./cmd/norouter
+	CGO_ENABLED=0 GOOS=linux     GOARCH=ppc64 $(GO) build -o ./bin/norouter-Linux-ppc64    ./cmd/norouter
+	CGO_ENABLED=0 GOOS=linux     GOARCH=ppc64le $(GO) build -o ./bin/norouter-Linux-ppc64le    ./cmd/norouter
+	CGO_ENABLED=0 GOOS=linux     GOARCH=mips64 $(GO) build -o ./bin/norouter-Linux-mips64    ./cmd/norouter
+	CGO_ENABLED=0 GOOS=linux     GOARCH=mips64le $(GO) build -o ./bin/norouter-Linux-mips64le    ./cmd/norouter
+	CGO_ENABLED=0 GOOS=linux     GOARCH=s390x $(GO) build -o ./bin/norouter-Linux-s390x    ./cmd/norouter
+	CGO_ENABLED=0 GOOS=linux     GOARCH=ppc64le $(GO) build -o ./bin/norouter-Linux-ppc64le    ./cmd/norouter
+#       CGO_ENABLED=0 GOOS=linux     GOARM=5 GOARCH=arm $(GO) build -o ./bin/norouter-Linux-armel    ./cmd/norouter
+#	CGO_ENABLED=0 GOOS=linux     GOARM=5 GOARCH=arm $(GO) build -o ./bin/norouter-Linux-armv5l    ./cmd/norouter
+#       CGO_ENABLED=0 GOOS=linux     GOARM=6 GOARCH=arm $(GO) build -o ./bin/norouter-Linux-armhf    ./cmd/norouter
+#	CGO_ENABLED=0 GOOS=linux     GOARM=6 GOARCH=arm $(GO) build -o ./bin/norouter-Linux-armv6l    ./cmd/norouter
+#	CGO_ENABLED=0 GOOS=linux     GOARM=7 GOARCH=arm $(GO) build -o ./bin/norouter-Linux-armv7l    ./cmd/norouter
+#	CGO_ENABLED=0 GOOS=windows   GO386=387 GOARCH=386 $(GO) build -o ./bin/norouter-Windows-x32.exe  ./cmd/norouter
+#	CGO_ENABLED=0 GOOS=js	     GOARCH=wasm $(GO) build -o ./bin/norouter-wasm  ./cmd/norouter
+
 
 clean:
 	rm -rf bin


### PR DESCRIPTION
add more archs / go crossbuild,

and after https://github.com/google/gvisor/pull/814 is fixed
the 32bit archs can be activated