### PR TITLE
Add `norouter --open-editor`

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ hosts:
     ports: ["8080:127.0.0.1:80"]
 ```
 
-The example can be also shown by running `norouter show-example`.
+The example can be also shown by running `norouter show-example`, or by running `norouter --open-editor`.
 
 ### Docker
 

--- a/cmd/norouter/main.go
+++ b/cmd/norouter/main.go
@@ -59,6 +59,7 @@ func newApp() *cli.App {
 			Destination: &debug,
 		},
 	}
+	app.Flags = append(app.Flags, managerFlags...)
 	app.Before = func(context *cli.Context) error {
 		if debug {
 			logrus.SetLevel(logrus.DebugLevel)

--- a/cmd/norouter/show_ex.go
+++ b/cmd/norouter/show_ex.go
@@ -30,10 +30,8 @@ var showExampleCommand = &cli.Command{
 	Action:  showExampleAction,
 }
 
-func exampleManifest() string {
-	s := `# Example manifest for NoRouter.
-# Run @BACKQUOTE@norouter <FILE>@BACKQUOTE@ to start NoRouter with the specified manifest file.
-#
+func exampleManifest(hdr string) string {
+	s := hdr + `#
 # The @BACKQUOTE@norouter@BACKQUOTE@ binary needs to be installed on all the remote hosts.
 # Run @BACKQUOTE@norouter show-installer@BACKQUOTE@ to show the installation script.
 #
@@ -73,6 +71,10 @@ hosts:
 }
 
 func showExampleAction(clicontext *cli.Context) error {
-	fmt.Print(exampleManifest())
+	hdr := `# Example manifest for NoRouter.
+# Run @BACKQUOTE@norouter <FILE>@BACKQUOTE@ to start NoRouter with the specified manifest file.
+`
+
+	fmt.Print(exampleManifest(hdr))
 	return nil
 }

--- a/cmd/norouter/show_ex_test.go
+++ b/cmd/norouter/show_ex_test.go
@@ -26,7 +26,7 @@ import (
 
 func TestExampleManifest(t *testing.T) {
 	var raw manifest.Manifest
-	if err := yaml.Unmarshal([]byte(exampleManifest()), &raw); err != nil {
+	if err := yaml.Unmarshal([]byte(exampleManifest("")), &raw); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := parsed.New(&raw); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.15
 
 require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect
+	github.com/mattn/go-isatty v0.0.12
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.7.0
 	github.com/urfave/cli/v2 v2.2.0

--- a/go.sum
+++ b/go.sum
@@ -110,6 +110,8 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.4-0.20190131011033-7dc38fb350b1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
+github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mohae/deepcopy v0.0.0-20170308212314-bb9b5e7adda9/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.10.1/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
@@ -230,6 +232,7 @@ golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191210023423-ac6580df4449/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200113162924-86b910548bc1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200120151820-655fe14d7479/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200217220822-9197077df867/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=

--- a/pkg/editorcmd/editorcmd.go
+++ b/pkg/editorcmd/editorcmd.go
@@ -1,0 +1,33 @@
+package editorcmd
+
+import (
+	"os"
+	"os/exec"
+	"runtime"
+)
+
+// Detect detects a text editor command.
+// Returns an empty string when no editor is found.
+func Detect() string {
+	var candidates = []string{
+		os.Getenv("VISUAL"),
+		os.Getenv("EDITOR"),
+		"editor",
+		"vim",
+		"vi",
+		"emacs",
+	}
+	if runtime.GOOS == "windows" {
+		candidates = append(candidates, "notepad.exe")
+	}
+	for _, f := range candidates {
+		if f == "" {
+			continue
+		}
+		x, err := exec.LookPath(f)
+		if err == nil {
+			return x
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
`norouter --open-editor` opens an editor for a temporary manifest file, with an example manifest.

