### PR TITLE
add http proxy mode for unprivileged name resolution

### DIFF
--- a/cmd/norouter/manager.go
+++ b/cmd/norouter/manager.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/mattn/go-isatty"
 	"github.com/norouter/norouter/pkg/editorcmd"
 	"github.com/norouter/norouter/pkg/manager"
@@ -160,6 +161,7 @@ func runManager(manifestPath string) error {
 	if err != nil {
 		return err
 	}
+	logrus.Debugf("parsed: %s", spew.Sdump(parsed))
 	ctx := context.Background()
 	ctx, cancel := context.WithCancel(ctx)
 	ccSet, err := manager.NewCmdClientSet(ctx, parsed)

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,8 @@ module github.com/norouter/norouter
 go 1.15
 
 require (
+	github.com/davecgh/go-spew v1.1.1
+	github.com/elazarl/goproxy v0.0.0-20201021153353-00ad82a08272
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/mattn/go-isatty v0.0.12
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,10 @@ github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c/go.mod h1:Uw6Uezg
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/dpjacques/clockwork v0.1.1-0.20200827220843-c1f524b839be/go.mod h1:D8mP2A8vVT2GkXqPorSBmhnshhkFBYgzhA90KmJt25Y=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/elazarl/goproxy v0.0.0-20201021153353-00ad82a08272 h1:Am81SElhR3XCQBunTisljzNkNese2T1FiV8jP79+dqg=
+github.com/elazarl/goproxy v0.0.0-20201021153353-00ad82a08272/go.mod h1:Ro8st/ElPeALwNFlcTpWmkr6IoMFfkjXAvTHpevnDsM=
+github.com/elazarl/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2 h1:dWB6v3RcOy03t/bUadywsbyrQwCqZeNIEX6M1OtSZOM=
+github.com/elazarl/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2/go.mod h1:gNh8nYJoAm43RfaxurUnxr+N1PwuFV3ZMl/efxlIlY8=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
@@ -80,7 +84,6 @@ github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5a
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.0 h1:/QaMHBdZ26BB3SSst0Iwl10Epc+xhTquomWX0oZEB6w=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.1 h1:JFrFEBb2xKufg6XkJsJr+WbKb4FQlURi5RUcBveYu9k=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
@@ -132,6 +135,7 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/procfs v0.0.0-20190522114515-bc1a522cf7b1/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
+github.com/rogpeppe/go-charset v0.0.0-20180617210344-2471d30d28b4/go.mod h1:qgYeAmZ5ZIpBWTGllZSQnw97Dj+woV0toclVaRGI8pc=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -266,7 +270,6 @@ golang.org/x/tools v0.0.0-20200117161641-43d50277825c/go.mod h1:TB2adYChydJhpapK
 golang.org/x/tools v0.0.0-20201002184944-ecd9fd270d5d/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/integration/test-integration.sh
+++ b/integration/test-integration.sh
@@ -64,6 +64,7 @@ test_wget() {
 	done
 }
 
+echo "Testing loopback mode"
 # Connect to host1 (nginx)
 test_wget http://127.0.42.101:8080 "Welcome to nginx"
 # Connect to host2 (Apache httpd)
@@ -75,6 +76,24 @@ echo "tests: $((N * 4 * 3)), succceeds: ${succeeds}, fails: ${fails}"
 if [ ${fails} -ne "0" ]; then
   exit ${fails}
 fi
+
+echo "Testing http proxy mode"
+set -x
+for ((i = 0; i < $N; i++)); do
+  for f in host1 host2 host3; do
+    curl -fsS -o /dev/null --proxy http://127.0.0.1:18080 http://${f}:8080
+  done
+done
+set +x
+
+echo "Testing http proxy mode (HTTP TUNNEL)"
+set -x
+for ((i = 0; i < $N; i++)); do
+  for f in host1 host2 host3; do
+    curl -fsS -o /dev/null --proxy http://127.0.0.1:18080 --proxytunnel http://${f}:8080
+  done
+done
+set +x
 
 echo "iperf3 from host2 to host1"
 docker exec host1 iperf3 -s > /dev/null &

--- a/integration/test-integration.yaml
+++ b/integration/test-integration.yaml
@@ -2,6 +2,8 @@ hosts:
   # host0 is the localhost
   host0:
     vip: "127.0.42.100"
+    http:
+      listen: "127.0.0.1:18080"
   host1:
     cmd: "docker exec -i host1 /mnt/norouter"
     vip: "127.0.42.101"

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -140,16 +140,20 @@ func (a *Agent) configure(args *jsonmsg.ConfigureRequestArgs) error {
 	a.config = args
 
 	for _, f := range a.config.Forwards {
-		if err := loopback.GoLocalForward(a.config.Me, f); err != nil {
-			return err
+		if !a.config.Loopback.Disable {
+			if err := loopback.GoLocalForward(a.config.Me, f); err != nil {
+				return err
+			}
 		}
 		if err := a.goGonetForward(a.config.Me, f); err != nil {
 			return err
 		}
 	}
 	for _, o := range a.config.Others {
-		if err := loopback.GoOther(a.stack, o); err != nil {
-			return err
+		if !a.config.Loopback.Disable {
+			if err := loopback.GoOther(a.stack, o); err != nil {
+				return err
+			}
 		}
 	}
 	if a.config.HTTP.Listen != "" {

--- a/pkg/agent/http/http.go
+++ b/pkg/agent/http/http.go
@@ -1,3 +1,19 @@
+/*
+   Copyright (C) NoRouter authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
 package http
 
 import (

--- a/pkg/agent/http/http.go
+++ b/pkg/agent/http/http.go
@@ -1,0 +1,109 @@
+package http
+
+import (
+	"bufio"
+	"context"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+
+	"github.com/elazarl/goproxy"
+	"github.com/norouter/norouter/pkg/bicopy"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"gvisor.dev/gvisor/pkg/tcpip"
+	"gvisor.dev/gvisor/pkg/tcpip/adapters/gonet"
+	"gvisor.dev/gvisor/pkg/tcpip/network/ipv4"
+	"gvisor.dev/gvisor/pkg/tcpip/stack"
+)
+
+// NewHandlerHandler returns a http.Handler that works as proxy.
+func NewHandler(st *stack.Stack, hostnameMap map[string]net.IP) (http.Handler, error) {
+	p := goproxy.NewProxyHttpServer()
+	for xhostname, xip := range hostnameMap {
+		hostname := xhostname
+		ip := xip
+		var cond goproxy.ReqConditionFunc = func(req *http.Request, ctx *goproxy.ProxyCtx) bool {
+			s := req.URL.Hostname()
+			return s == hostname || s == ip.String()
+		}
+		var doFunc = func(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
+			resp, err := do(st, ip, req, ctx)
+			if err != nil {
+				logrus.WithError(err).Warn("failed to call do()")
+				return req, goproxy.NewResponse(req,
+					goproxy.ContentTypeText, http.StatusInternalServerError,
+					"See NoRouter agent log\n")
+			}
+			return req, resp
+		}
+		p.OnRequest(cond).DoFunc(doFunc)
+		var hijackFunc = func(req *http.Request, clientConn net.Conn, ctx *goproxy.ProxyCtx) {
+			defer clientConn.Close()
+			if err := hijack(st, ip, req, clientConn, ctx); err != nil {
+				logrus.WithError(err).Warn("failed to call hijack()")
+				clientConn.Write([]byte("HTTP/1.1 500 Cannot reach destination\r\n\r\n"))
+			}
+		}
+		p.OnRequest(cond).HijackConnect(hijackFunc)
+	}
+	return p, nil
+}
+
+func do(st *stack.Stack, ip net.IP, req *http.Request, ctx *goproxy.ProxyCtx) (*http.Response, error) {
+	gonetDialConn, err := gonetDial(st, ip, req)
+	if err != nil {
+		return nil, err
+	}
+	// Do NOT defer close gonetDialConn
+	remoteBuf := bufio.NewReadWriter(bufio.NewReader(gonetDialConn), bufio.NewWriter(gonetDialConn))
+	if err := req.Write(gonetDialConn); err != nil {
+		return nil, err
+	}
+	if err := remoteBuf.Flush(); err != nil {
+		return nil, err
+	}
+	resp, err := http.ReadResponse(remoteBuf.Reader, req)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func hijack(st *stack.Stack, ip net.IP, req *http.Request, clientConn net.Conn, ctx *goproxy.ProxyCtx) error {
+	gonetDialConn, err := gonetDial(st, ip, req)
+	if err != nil {
+		return err
+	}
+	defer gonetDialConn.Close()
+	clientConn.Write([]byte("HTTP/1.1 200 Ok\r\n\r\n"))
+	bicopy.Bicopy(clientConn, gonetDialConn, nil)
+	return nil
+}
+
+func gonetDial(st *stack.Stack, ip net.IP, req *http.Request) (net.Conn, error) {
+	port, err := portNumFromURL(req.URL)
+	if err != nil {
+		return nil, err
+	}
+	fullAddr := tcpip.FullAddress{
+		Addr: tcpip.Address(ip),
+		Port: uint16(port),
+	}
+	return gonet.DialContextTCP(context.TODO(), st, fullAddr, ipv4.ProtocolNumber)
+}
+
+func portNumFromURL(u *url.URL) (int, error) {
+	s := u.Port()
+	if s != "" {
+		return strconv.Atoi(s)
+	}
+	switch u.Scheme {
+	case "http":
+		return 80, nil
+	case "https":
+		return 443, nil
+	}
+	return 0, errors.Errorf("url seems to lack port: %q", u.String())
+}

--- a/pkg/agent/loopback/loopback.go
+++ b/pkg/agent/loopback/loopback.go
@@ -1,0 +1,110 @@
+/*
+   Copyright (C) NoRouter authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package loopback
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"runtime"
+	"strings"
+	"syscall"
+
+	"github.com/norouter/norouter/pkg/bicopy"
+	"github.com/norouter/norouter/pkg/bicopy/bicopyutil"
+	"github.com/norouter/norouter/pkg/stream/jsonmsg"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"gvisor.dev/gvisor/pkg/tcpip"
+	"gvisor.dev/gvisor/pkg/tcpip/adapters/gonet"
+	"gvisor.dev/gvisor/pkg/tcpip/network/ipv4"
+	"gvisor.dev/gvisor/pkg/tcpip/stack"
+)
+
+func isBSD(goos string) bool {
+	if strings.Contains(goos, "bsd") {
+		return true
+	}
+	switch goos {
+	case "darwin", "dragonfly":
+		return true
+	}
+	return false
+}
+
+func listen(proto, addr string) (net.Listener, error) {
+	l, err := net.Listen(proto, addr)
+	if err != nil {
+		// "listen tcp 127.0.43.101:8080: bind: can't assign requested address"
+		if errors.Is(err, syscall.EADDRNOTAVAIL) || strings.Contains(err.Error(), "can't assign requested address") {
+			if isBSD(runtime.GOOS) {
+				err = errors.Wrap(err, "hint: try running `sudo ifconfig lo0 alias <IP>`")
+			}
+		}
+	}
+	return l, err
+}
+
+// GoOther forwards connections to "others" VIP such as 127.0.42.102:8080, 127.0.42.103:8080..
+// to the netstack network.
+func GoOther(st *stack.Stack, o jsonmsg.IPPortProto) error {
+	lh := fmt.Sprintf("%s:%d", o.IP, o.Port)
+	l, err := listen(o.Proto, lh)
+	if err != nil {
+		return err
+	}
+	go func() {
+		for {
+			acceptConn, err := l.Accept()
+			if err != nil {
+				logrus.WithError(err).Error("failed to call l.Accept")
+				continue
+			}
+			fullAddr := tcpip.FullAddress{
+				Addr: tcpip.Address(o.IP),
+				Port: o.Port,
+			}
+			gonetDialConn, err := gonet.DialContextTCP(context.TODO(), st, fullAddr, ipv4.ProtocolNumber)
+			if err != nil {
+				logrus.WithError(err).Error("failed to call gonet.DialContextTCP")
+				acceptConn.Close()
+				continue
+			}
+			go func() {
+				defer acceptConn.Close()
+				defer gonetDialConn.Close()
+				bicopy.Bicopy(gonetDialConn, acceptConn, nil)
+			}()
+		}
+	}()
+	return nil
+}
+
+// GoLocalForward forwards connections to "my" VIP such as 127.0.42.101:8080
+// to the underlying application such as 127.0.0.1:80
+func GoLocalForward(me net.IP, f jsonmsg.Forward) error {
+	if f.Proto != "tcp" {
+		return errors.Errorf("expected proto be \"tcp\", got %q", f.Proto)
+	}
+	lh := fmt.Sprintf("%s:%d", me.String(), f.ListenPort)
+	l, err := listen(f.Proto, lh)
+	if err != nil {
+		return errors.Wrapf(err, "failed to listen on %q", lh)
+	}
+	go bicopyutil.BicopyAcceptDial(l, f.Proto, fmt.Sprintf("%s:%d", f.ConnectIP.String(), f.ConnectPort), net.Dial)
+	return nil
+}

--- a/pkg/agent/loopback/loopback_test.go
+++ b/pkg/agent/loopback/loopback_test.go
@@ -1,0 +1,37 @@
+/*
+   Copyright (C) NoRouter authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package loopback
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestIsBSD(t *testing.T) {
+	testCases := map[string]bool{
+		"linux":     false,
+		"windows":   false,
+		"freebsd":   true,
+		"darwin":    true,
+		"dragonfly": true,
+	}
+	for goos, expected := range testCases {
+		got := isBSD(goos)
+		assert.Equal(t, expected, got)
+	}
+}

--- a/pkg/bicopy/bicopyutil/bicopyutil.go
+++ b/pkg/bicopy/bicopyutil/bicopyutil.go
@@ -1,0 +1,46 @@
+/*
+   Copyright (C) NoRouter authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package bicopyutil
+
+import (
+	"net"
+
+	"github.com/norouter/norouter/pkg/bicopy"
+	"github.com/sirupsen/logrus"
+)
+
+type DialFunc = func(string, string) (net.Conn, error)
+
+func BicopyAcceptDial(l net.Listener, dialProto, dialHost string, dialFunc DialFunc) {
+	for {
+		acceptConn, err := l.Accept()
+		if err != nil {
+			logrus.WithError(err).Error("failed to accept")
+			continue
+		}
+		go func() {
+			defer acceptConn.Close()
+			dialConn, err := dialFunc(dialProto, dialHost)
+			if err != nil {
+				logrus.WithError(err).Errorf("failed to dial to %q (%q)", dialHost, dialProto)
+				return
+			}
+			defer dialConn.Close()
+			bicopy.Bicopy(acceptConn, dialConn, nil)
+		}()
+	}
+}

--- a/pkg/editorcmd/editorcmd.go
+++ b/pkg/editorcmd/editorcmd.go
@@ -1,3 +1,19 @@
+/*
+   Copyright (C) NoRouter authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
 package editorcmd
 
 import (

--- a/pkg/manager/cmdclient.go
+++ b/pkg/manager/cmdclient.go
@@ -83,6 +83,7 @@ func NewCmdClient(ctx context.Context, hostname string, pm *parsed.ParsedManifes
 		configRequestArgs.HostnameMap[k] = v.VIP
 	}
 	configRequestArgs.HTTP.Listen = h.HTTP.Listen
+	configRequestArgs.Loopback.Disable = h.Loopback.Disable
 	configRequestArgsB, err := json.Marshal(configRequestArgs)
 	if err != nil {
 		return nil, err
@@ -105,19 +106,21 @@ func NewCmdClient(ctx context.Context, hostname string, pm *parsed.ParsedManifes
 		return nil, err
 	}
 	c := &CmdClient{
-		Hostname:         hostname,
-		VIP:              h.VIP.String(),
-		cmd:              cmd,
-		configRequestMsg: msgB,
+		Hostname:          hostname,
+		VIP:               h.VIP.String(),
+		cmd:               cmd,
+		configRequestMsg:  msgB,
+		configRequestArgs: configRequestArgs,
 	}
 	return c, nil
 }
 
 type CmdClient struct {
-	Hostname         string
-	VIP              string
-	cmd              *exec.Cmd
-	configRequestMsg json.RawMessage
+	Hostname          string
+	VIP               string
+	cmd               *exec.Cmd
+	configRequestMsg  json.RawMessage
+	configRequestArgs jsonmsg.ConfigureRequestArgs
 }
 
 func (c *CmdClient) String() string {

--- a/pkg/manager/cmdclient.go
+++ b/pkg/manager/cmdclient.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"runtime"
@@ -77,6 +78,11 @@ func NewCmdClient(ctx context.Context, hostname string, pm *parsed.ParsedManifes
 		}
 		configRequestArgs.Others = append(configRequestArgs.Others, *pub)
 	}
+	configRequestArgs.HostnameMap = make(map[string]net.IP)
+	for k, v := range pm.Hosts {
+		configRequestArgs.HostnameMap[k] = v.VIP
+	}
+	configRequestArgs.HTTP.Listen = h.HTTP.Listen
 	configRequestArgsB, err := json.Marshal(configRequestArgs)
 	if err != nil {
 		return nil, err

--- a/pkg/manager/manifest/manifest.go
+++ b/pkg/manager/manifest/manifest.go
@@ -50,4 +50,10 @@ type Host struct {
 	// Ports are appended to HostTemplate.Ports
 	// when HostTemplate is specified.
 	Ports []string `yaml:"ports,omitempty"`
+
+	HTTP *HTTP `yaml:"http,omitempty"`
+}
+
+type HTTP struct {
+	Listen string `yaml:"listen,omitempty"`
 }

--- a/pkg/manager/manifest/manifest.go
+++ b/pkg/manager/manifest/manifest.go
@@ -51,9 +51,25 @@ type Host struct {
 	// when HostTemplate is specified.
 	Ports []string `yaml:"ports,omitempty"`
 
+	// HTTP can be specified since NoRouter v0.4.0
 	HTTP *HTTP `yaml:"http,omitempty"`
+
+	// Loopback can be specified since NoRouter v0.4.0
+	Loopback *Loopback `yaml:"loopback,omitempty"`
 }
 
+// HTTP can be specified since NoRouter v0.4.0
 type HTTP struct {
+	// Listen specifies an address of HTTP proxy to be listened by NoRouter agent processes.
+	// The address is typically a local address, e.g. "127.0.0.1:18080".
+	// When the address is not specified, HTTP proxy is disabled.
 	Listen string `yaml:"listen,omitempty"`
+}
+
+// Loopback can be specified since NoRouter v0.4.0
+type Loopback struct {
+	// Disable disables listening on multi-loopback addresses such as 127.0.42.100, 127.0.42.101...
+	//
+	// When Disable is set, HTTP.Listen should be specified to enable HTTP proxy.
+	Disable bool `yaml:"disable,omitempty"`
 }

--- a/pkg/manager/manifest/manifest.go
+++ b/pkg/manager/manifest/manifest.go
@@ -17,7 +17,10 @@
 package manifest
 
 type Manifest struct {
-	Hosts map[string]Host `yaml:"hosts"`
+	// HostTemplate is optional.
+	// HostTemplate must not contain VIP and Cmd.
+	HostTemplate *Host           `yaml:"hostTemplate"`
+	Hosts        map[string]Host `yaml:"hosts"`
 }
 
 type Host struct {
@@ -43,5 +46,8 @@ type Host struct {
 	// e.g. ["8080:127.0.0.1:80/tcp"]
 	//
 	// Ports are optional.
+	//
+	// Ports are appended to HostTemplate.Ports
+	// when HostTemplate is specified.
 	Ports []string `yaml:"ports,omitempty"`
 }

--- a/pkg/manager/manifest/parsed/parsed.go
+++ b/pkg/manager/manifest/parsed/parsed.go
@@ -34,10 +34,15 @@ type ParsedManifest struct {
 }
 
 type Host struct {
-	Cmd   []string
-	VIP   net.IP
-	Ports []*jsonmsg.Forward
-	HTTP  HTTP
+	Cmd      []string
+	VIP      net.IP
+	Ports    []*jsonmsg.Forward
+	HTTP     HTTP
+	Loopback Loopback
+}
+
+type Loopback struct {
+	Disable bool
 }
 
 type HTTP struct {
@@ -96,12 +101,21 @@ func New(raw *manifest.Manifest) (*ParsedManifest, error) {
 					Proto: f.Proto,
 				})
 		}
-		if raw.HostTemplate != nil && raw.HostTemplate.HTTP != nil {
-			h.HTTP.Listen = raw.HostTemplate.HTTP.Listen
+		if raw.HostTemplate != nil {
+			if raw.HostTemplate.HTTP != nil {
+				h.HTTP.Listen = raw.HostTemplate.HTTP.Listen
+			}
+			if raw.HostTemplate.Loopback != nil {
+				h.Loopback.Disable = raw.HostTemplate.Loopback.Disable
+			}
 		}
 		if rh.HTTP != nil {
 			h.HTTP.Listen = rh.HTTP.Listen
 		}
+		if rh.Loopback != nil {
+			h.Loopback.Disable = rh.Loopback.Disable
+		}
+
 		pm.Hosts[name] = h
 		uniqueVIPs[rh.VIP] = struct{}{}
 	}

--- a/pkg/manager/manifest/parsed/parsed.go
+++ b/pkg/manager/manifest/parsed/parsed.go
@@ -37,6 +37,11 @@ type Host struct {
 	Cmd   []string
 	VIP   net.IP
 	Ports []*jsonmsg.Forward
+	HTTP  HTTP
+}
+
+type HTTP struct {
+	Listen string
 }
 
 func New(raw *manifest.Manifest) (*ParsedManifest, error) {
@@ -90,6 +95,12 @@ func New(raw *manifest.Manifest) (*ParsedManifest, error) {
 					Port:  f.ListenPort,
 					Proto: f.Proto,
 				})
+		}
+		if raw.HostTemplate != nil && raw.HostTemplate.HTTP != nil {
+			h.HTTP.Listen = raw.HostTemplate.HTTP.Listen
+		}
+		if rh.HTTP != nil {
+			h.HTTP.Listen = rh.HTTP.Listen
 		}
 		pm.Hosts[name] = h
 		uniqueVIPs[rh.VIP] = struct{}{}

--- a/pkg/manager/manifest/parsed/parsed_test.go
+++ b/pkg/manager/manifest/parsed/parsed_test.go
@@ -80,6 +80,22 @@ hosts:
 `,
 			expectedError: "expected to have 3 unique virtual IPs (VIPs)",
 		},
+		{
+			s: `# valid manifest with hostTemplate
+hostTemplate:
+  ports: ["8080:127.0.0.1:80"]
+hosts:
+  foo:
+    vip: "127.0.42.100"
+  bar:
+    cmd: ["docker", "exec", "-i", "foo", "norouter"]
+    vip: "127.0.42.101"
+  baz:
+    cmd: ["docker", "exec", "-i", "bar", "norouter"]
+    vip: 127.0.42.102
+    ports: ["8081:127.0.0.1:81"]
+`,
+		},
 	}
 
 	for i, c := range testCases {

--- a/pkg/stream/jsonmsg/configure.go
+++ b/pkg/stream/jsonmsg/configure.go
@@ -27,9 +27,13 @@ const (
 )
 
 type ConfigureRequestArgs struct {
+	// Fields added in v0.2.0
 	Me       net.IP        `json:"me"` // Required
 	Forwards []Forward     `json:"forwards,omitempty"`
 	Others   []IPPortProto `json:"others,omitempty"`
+	// Fields added in v0.4.0
+	HostnameMap map[string]net.IP `json:"hostnameMap,omitempty"` // hostname -> ip
+	HTTP        HTTP              `json:"http,omitempty"`
 }
 
 type ConfigureResultData struct {
@@ -49,4 +53,8 @@ type IPPortProto struct {
 	IP    net.IP `json:"ip"`
 	Port  uint16 `json:"port"`
 	Proto string `json:"proto"`
+}
+
+type HTTP struct {
+	Listen string `json:"listen,omitempty"`
 }

--- a/pkg/stream/jsonmsg/configure.go
+++ b/pkg/stream/jsonmsg/configure.go
@@ -34,6 +34,7 @@ type ConfigureRequestArgs struct {
 	// Fields added in v0.4.0
 	HostnameMap map[string]net.IP `json:"hostnameMap,omitempty"` // hostname -> ip
 	HTTP        HTTP              `json:"http,omitempty"`
+	Loopback    Loopback          `json:"loopback,omitempty"`
 }
 
 type ConfigureResultData struct {
@@ -57,4 +58,8 @@ type IPPortProto struct {
 
 type HTTP struct {
 	Listen string `json:"listen,omitempty"`
+}
+
+type Loopback struct {
+	Disable bool `json:"disable,omitempty"`
 }

--- a/pkg/version/features.go
+++ b/pkg/version/features.go
@@ -20,12 +20,13 @@ type Feature = string
 
 const (
 	// Features introduced in v0.2.0:
-	FeatureLoopback = "loopback" // Listening on loopback IPs
+	FeatureLoopback = "loopback" // Listening on multiple loopback IPs such as 127.0.42.101, 127.0.42.102, ...
 	FeatureTCP      = "tcp"      // TCP v4 stream
 	// Features introduced in v0.4.0:
-	FeatureHTTP = "http" // Listening on HTTP for proxy
+	FeatureHTTP            = "http"             // Listening on HTTP for proxy
+	FeatureDisableLoopback = "disable-loopback" // Disabling loopback
 	// Features introduced in vX.Y.Z:
 	// ...
 )
 
-var Features = []Feature{FeatureLoopback, FeatureTCP, FeatureHTTP}
+var Features = []Feature{FeatureLoopback, FeatureTCP, FeatureHTTP, FeatureDisableLoopback}

--- a/pkg/version/features.go
+++ b/pkg/version/features.go
@@ -22,8 +22,10 @@ const (
 	// Features introduced in v0.2.0:
 	FeatureLoopback = "loopback" // Listening on loopback IPs
 	FeatureTCP      = "tcp"      // TCP v4 stream
+	// Features introduced in v0.4.0:
+	FeatureHTTP = "http" // Listening on HTTP for proxy
 	// Features introduced in vX.Y.Z:
 	// ...
 )
 
-var Features = []Feature{FeatureLoopback, FeatureTCP}
+var Features = []Feature{FeatureLoopback, FeatureTCP, FeatureHTTP}


### PR DESCRIPTION
Now agent processes can serve HTTP proxies that can be used for connecting to HTTP-based applications.

Pro: Can look up virtual hostnames
Con: Doesn't work with non-HTTP apps

e.g.
```yaml
hosts:
  local:
    vip: 127.0.42.100
    http:
      listen: "127.0.0.1:18080"
  foo:
    cmd: ...
    vip: 127.0.42.101
    ports: ["8080:127.0.0.1:80"]
  bar:
    cmd: ...
    vip: 127.0.42.102
    ports: ["8080:127.0.0.1:80"]
```

```console
$ export http_proxy=127.0.0.1:8080
$ curl http://foo:8080
$ curl http://bar:8080
$ curl -p http://foo:8080
$ curl -p http://bar:8080
```

`curl -p` produces the same result but uses `HTTP CONNECT`.
TODO:  support SOCKS

- - -

Fix #20