### PR TITLE
Compress artifact binaries as tgz

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       run: make cross
     - name: "SHA256SUMS"
       working-directory:  go/src/github.com/norouter/norouter
-      run: ( cd ./bin; sha256sum norouter-* ) | tee /tmp/SHA256SUMS
+      run: ( cd ./artifacts; sha256sum norouter-* ) | tee /tmp/SHA256SUMS
     - name: "The sha256sum of the SHA256SUMS file"
       run: sha256sum /tmp/SHA256SUMS
     - name: "Prepare the release note"
@@ -42,16 +42,14 @@ jobs:
 
         #### Install
         \`\`\`
-        curl -o norouter --fail -L https://github.com/${{ github.repository }}/releases/download/${tag}/norouter-\$(uname -s)-\$(uname -m)
-        chmod +x norouter
+        curl -fsSL https://github.com/${{ github.repository }}/releases/download/${tag}/norouter-\$(uname -s)-\$(uname -m).tgz | sudo tar xzvC /usr/local/bin
         \`\`\`
 
         #### About the binaries
         The binaries were built automatically on GitHub Actions.
-        See the log to verify SHA256SUMS.
-        https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        The build log is available for 90 days: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
-        The sha256sum of the SHA256SUMS file itself is ${shasha} .
+        The sha256sum of the SHA256SUMS file itself is \`${shasha}\` .
         EOF
     - name: "Create release"
       working-directory:  go/src/github.com/norouter/norouter
@@ -60,5 +58,5 @@ jobs:
       run: |
         tag="${GITHUB_REF##*/}"
         asset_flags=()
-        for f in ./bin/* /tmp/SHA256SUMS; do asset_flags+=("-a" "$f"); done
+        for f in ./artifacts/* /tmp/SHA256SUMS; do asset_flags+=("-a" "$f"); done
         hub release create "${asset_flags[@]}" -F /tmp/release-note.txt --draft "${tag}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /bin
+/artifacts
 /docs.source/public
 /docs.source/resources
 /docs.source/node_modules

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,10 @@
 
 GO := go
 
+GO_BUILD := GO111MODULE=on CGO_ENABLED=0 $(GO) build -ldflags="-s -w"
+
+TARFLAGS := --owner=0 --group=0
+
 binary: bin/norouter
 
 install:
@@ -11,22 +15,44 @@ uninstall:
 	rm -f /usr/local/bin/norouter
 
 bin/norouter:
-	CGO_ENABLED=0 $(GO) build -o $@ ./cmd/norouter
+	rm -f $@$(shell go env GOEXE)
+	$(GO_BUILD) -o $@$(shell go env GOEXE) ./cmd/norouter
 	if [ $(shell go env GOOS) = linux ]; then LANG=C LC_ALL=C file $@ | grep -qw "statically linked"; fi
 
-# The file name convention for Unix: ./bin/norouter-$(uname -s)-$(uname -m)
+# The file name convention for Unix: ./artifacts/norouter-$(uname -s)-$(uname -m).tgz
+# The file name convention has changed in v0.6.0.
 cross:
-	CGO_ENABLED=0 GOOS=linux     GOARCH=amd64 $(GO) build -o ./bin/norouter-Linux-x86_64     ./cmd/norouter
-	CGO_ENABLED=0 GOOS=linux     GOARCH=arm64 $(GO) build -o ./bin/norouter-Linux-aarch64    ./cmd/norouter
-	CGO_ENABLED=0 GOOS=darwin    GOARCH=amd64 $(GO) build -o ./bin/norouter-Darwin-x86_64    ./cmd/norouter
-	CGO_ENABLED=0 GOOS=freebsd   GOARCH=amd64 $(GO) build -o ./bin/norouter-FreeBSD-amd64    ./cmd/norouter
-	CGO_ENABLED=0 GOOS=netbsd    GOARCH=amd64 $(GO) build -o ./bin/norouter-NetBSD-amd64     ./cmd/norouter
-	CGO_ENABLED=0 GOOS=openbsd   GOARCH=amd64 $(GO) build -o ./bin/norouter-OpenBSD-amd64    ./cmd/norouter
-	CGO_ENABLED=0 GOOS=dragonfly GOARCH=amd64 $(GO) build -o ./bin/norouter-DragonFly-x86_64 ./cmd/norouter
-	CGO_ENABLED=0 GOOS=windows   GOARCH=amd64 $(GO) build -o ./bin/norouter-Windows-x64.exe  ./cmd/norouter
+	rm -rf bin artifacts
+	mkdir -p artifacts
+
+	GOOS=linux     GOARCH=amd64 make binary
+	tar czvf artifacts/norouter-Linux-x86_64.tgz     $(TARFLAGS) -C bin norouter
+
+	GOOS=linux     GOARCH=arm64 make binary
+	tar czvf artifacts/norouter-Linux-aarch64.tgz    $(TARFLAGS) -C bin norouter
+
+	GOOS=darwin    GOARCH=amd64 make binary
+	tar czvf artifacts/norouter-Darwin-x86_64.tgz    $(TARFLAGS) -C bin norouter
+
+	GOOS=freebsd   GOARCH=amd64 make binary
+	tar czvf artifacts/norouter-FreeBSD-amd64.tgz    $(TARFLAGS) -C bin norouter
+
+	GOOS=netbsd    GOARCH=amd64 make binary
+	tar czvf artifacts/norouter-NetBSD-amd64.tgz     $(TARFLAGS) -C bin norouter
+
+	GOOS=openbsd   GOARCH=amd64 make binary
+	tar czvf artifacts/norouter-OpenBSD-amd64.tgz    $(TARFLAGS) -C bin norouter
+
+	GOOS=dragonfly GOARCH=amd64 make binary
+	tar czvf artifacts/norouter-DragonFly-x86_64.tgz $(TARFLAGS) -C bin norouter
+
+	GOOS=windows   GOARCH=amd64 make binary
+	zip -X -j artifacts/norouter-Windows-x64.zip bin/norouter.exe 
+
+	rm -rf bin
 
 clean:
-	rm -rf bin
+	rm -rf bin artifacts
 
 integration:
 	./integration/test-agent.sh

--- a/cmd/norouter/show_installer.go
+++ b/cmd/norouter/show_installer.go
@@ -49,40 +49,41 @@ echo "# Destination: ${bindir}/norouter"
 mkdir -p "${bindir}"
 
 download(){
-  local="$1"
+	local="$1"
 	remote="$2"
 	echo "# Downloading ${remote}"
 	if command -v curl >/dev/null 2>&1; then
 		( set -x; curl -fL -o "$local" "$remote" )
 	elif command -v wget >/dev/null 2>&1; then
-	  ( set -x; wget -O "$local" "$remote" )
-  else
-	  echo >&2 "curl or wget needs to be installed"
+		( set -x; wget -O "$local" "$remote" )
+	else
+		echo >&2 "curl or wget needs to be installed"
 		exit 1
 	fi
 }
 
-fname="norouter-$(uname -s)-$(uname -m)"
+fname="norouter-$(uname -s)-$(uname -m).tgz"
 tmp=$(mktemp -d)
 download "${tmp}/${fname}" "https://github.com/norouter/norouter/releases/download/v${version}/${fname}"
-chmod +x "${tmp}/${fname}"
 download "${tmp}/SHA256SUMS" "https://github.com/norouter/norouter/releases/download/v${version}/SHA256SUMS"
 
 if command -v sha256sum &> /dev/null; then
-  (
-	  cd "${tmp}"
+	(
+		cd "${tmp}"
 		echo "# Printing sha256sum of SHA256SUMS file itself"
 		sha256sum SHA256SUMS
 		echo "# Checking SHA256SUMS"
-    grep "${fname}" SHA256SUMS | sha256sum -c -
+		grep "${fname}" SHA256SUMS | sha256sum -c -
+		echo "# Extracting norouter executable"
+		tar xzvf "${fname}"
 	)
 fi
 if [ -x "${bindir}/norouter" ]; then
-  echo "# Removing existing ${bindir}/norouter"
-  rm -f "${bindir}/norouter"
+	echo "# Removing existing ${bindir}/norouter"
+	rm -f "${bindir}/norouter"
 fi
-echo "# Installing ${fname} onto ${bindir}/norouter"
-mv "${tmp}/${fname}" "${bindir}/norouter"
+echo "# Installing ${tmp}/norouter onto ${bindir}/norouter"
+mv "${tmp}/norouter" "${bindir}/norouter"
 
 rm -rf "${tmp}"
 

--- a/docs.source/content/en/docs/Command reference/norouter-show-installer.md
+++ b/docs.source/content/en/docs/Command reference/norouter-show-installer.md
@@ -6,6 +6,8 @@ weight: 41
 
 `norouter show-install` the installer script to replicate the same version of `norouter` binary to other hosts.
 
+The binary is located as `~/bin/norouter`.
+
 ## Examples
 
 Show the installer script:
@@ -13,16 +15,10 @@ Show the installer script:
 ```console
 $ norouter show-installer
 #!/bin/sh
-set -eux
+set -eu
 # Installation script for NoRouter
 # NOTE: make sure to use the same version across all the hosts.
-version="0.3.0"
-bindir="$HOME/bin"
-mkdir -p "${bindir}"
-rm -f "${bindir}/norouter"
-curl -o "${bindir}/norouter" --fail -L https://github.com/norouter/norouter/releases/download/v${version}/norouter-$(uname -s)-$(uname -m)
-chmod +x "${bindir}/norouter"
-echo "Successfully installed ${bindir}/norouter (version ${version})"
+...
 ```
 
 Inject the script to a remote SSH host:
@@ -30,7 +26,7 @@ Inject the script to a remote SSH host:
 ```console
 $ norouter show-installer | ssh some-user@example.com
 ...
-Successfully installed /home/some-user/bin/norouter (version 0.3.0)
+Successfully installed /home/some-user/bin/norouter (version 0.6.0)
 ```
 
 ## norouter show-installer --help

--- a/docs.source/content/en/docs/Command reference/norouter.md
+++ b/docs.source/content/en/docs/Command reference/norouter.md
@@ -37,7 +37,7 @@ Show the NoRouter version:
 
 ```console
 $ norouter -v
-norouter version 0.3.0
+norouter version 0.6.0
 ```
 
 ## norouter --help
@@ -50,22 +50,21 @@ USAGE:
    norouter [global options] command [command options] [arguments...]
 
 VERSION:
-   0.3.0
+   0.6.0
 
 DESCRIPTION:
+   NoRouter is the easiest multi-host & multi-cloud networking ever.
+   And yet, NoRouter does not require any privilege such as `sudo` or `docker run --privileged`.
    
-  NoRouter is the easiest multi-host & multi-cloud networking ever.
-  And yet, NoRouter does not require any privilege such as `sudo` or `docker run --privileged`.
-
-  NoRouter implements unprivileged networking by using multiple loopback addresses such as 127.0.42.101 and 127.0.42.102.
-  The hosts in the network are connected by forwarding packets over stdio streams like `ssh`, `docker exec`, `podman exec`, `kubectl exec`, and whatever.
-
-  Quick usage:
-  - Install the `norouter` binary to all the hosts. Run `norouter show-installer` to show an installation script.
-  - Create a manifest YAML file. Run `norouter show-example` to show an example manifest.
-  - Run `norouter <FILE>` to start NoRouter with the specified manifest YAML file.
-
-  Documentation: https://github.com/norouter/norouter
+   NoRouter implements unprivileged networking by using multiple loopback addresses such as 127.0.42.101 and 127.0.42.102.
+   The hosts in the network are connected by forwarding packets over stdio streams like `ssh`, `docker exec`, `podman exec`, `kubectl exec`, and whatever.
+   
+   Quick usage:
+   - Install the `norouter` binary to all the hosts. Run `norouter show-installer` to show an installation script.
+   - Create a manifest YAML file. Run `norouter show-example` to show an example manifest.
+   - Run `norouter <FILE>` to start NoRouter with the specified manifest YAML file.
+   
+   Web site: https://norouter.io
 
 COMMANDS:
    manager, m             manager (default subcommand)

--- a/docs.source/content/en/docs/Getting started/download.md
+++ b/docs.source/content/en/docs/Getting started/download.md
@@ -14,14 +14,19 @@ Download from https://github.com/norouter/norouter/releases .
 Or copy the following script to a terminal:
 
 ```bash
-curl -o norouter --fail -L https://github.com/norouter/norouter/releases/latest/download/norouter-$(uname -s)-$(uname -m)
-chmod +x norouter
+curl -fsSL https://github.com/norouter/norouter/releases/latest/download/norouter-$(uname -s)-$(uname -m).tgz | sudo tar xzvC /usr/local/bin
 ```
 
 {{% alert %}}
 **Note**
 
 Make sure to use the (almost) same version of NoRouter across all the hosts.
+{{% /alert %}}
+
+{{% alert %}}
+**Note**
+
+The URL has changed in NoRouter v0.6.0.
 {{% /alert %}}
 
 ## Already have a norouter binary?

--- a/docs.source/content/en/docs/Getting started/first-example.md
+++ b/docs.source/content/en/docs/Getting started/first-example.md
@@ -26,20 +26,19 @@ The easiest way is to download the binary on the local host first, and then use
 `norouter show-installer | ssh <USER>@<HOST>` to replicate the binary.
 
 ```console
-$ curl -o norouter --fail -L https://github.com/norouter/norouter/releases/latest/download/norouter-$(uname -s)-$(uname -m)
-$ chmod +x norouter
+$ curl -fsSL https://github.com/norouter/norouter/releases/latest/download/norouter-$(uname -s)-$(uname -m).tgz | sudo tar xzvC /usr/local/bin
 ```
 
 ```console
 $ norouter show-installer | ssh some-user@host1.cloud1.example.com
 ...
-Successfully installed /home/some-user/bin/norouter (version 0.3.0)
+Successfully installed /home/some-user/bin/norouter (version 0.6.0)
 ```
 
 ```console
 $ norouter show-installer | ssh some-user@host2.cloud2.example.com
 ...
-Successfully installed /home/some-user/bin/norouter (version 0.3.0)
+Successfully installed /home/some-user/bin/norouter (version 0.6.0)
 ```
 
 ## Step 1: Create a manifest

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -17,10 +17,10 @@
 package version
 
 const (
-	Version = "0.5.1+dev"
+	Version = "0.6.0"
 
 	// LatestOfficialStableRelease is used by `norouter show-installer` command.
 	//
 	// The release must be available on https://github.com/norouter/norouter/releases .
-	LatestOfficialStableRelease = "0.5.1"
+	LatestOfficialStableRelease = "0.6.0"
 )

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -17,7 +17,7 @@
 package version
 
 const (
-	Version = "0.6.0"
+	Version = "0.6.0+dev"
 
 	// LatestOfficialStableRelease is used by `norouter show-installer` command.
 	//


### PR DESCRIPTION
- Old artifact name convention: "norouter-$(uname -s)-$(uname -m)"
- New artifact name convention: "norouter-$(uname -s)-$(uname -m).tgz"
    
The archive contains "norouter" executable.
On Windows, "norouter-$(uname -s)-$(uname -m).zip" contains "norouter.exe".