### PR TITLE
Changed code color in documentation to make it more readable

### DIFF
--- a/docs.source/assets/scss/_variables_project.scss
+++ b/docs.source/assets/scss/_variables_project.scss
@@ -4,3 +4,4 @@ $secondary: #fff;
 $dark: #213d7a;
 $info: #adb5bd;
 $light: #dee2e6;
+$code-color: #555;


### PR DESCRIPTION
This PR changes the color of the `code` tag to have higher contrast and make it more readable in text.